### PR TITLE
allText and noneText options for button labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ You can pass a number of options into `.multiSelect()` to customise the HTML out
         buttonHTML: '<button class="btn btn-default">',
         menuItemHTML: '<label>',
         activeClass: 'dropdown-menu--open',
-        placeholderText: '-- Choisir --'
+        noneText: '-- Choisir --',
+        allText: 'Tout le monde'
     });
 
 ## See a demo

--- a/src/jquery.multi-select.js
+++ b/src/jquery.multi-select.js
@@ -13,7 +13,8 @@
       buttonHTML: '<span class="multi-select-button">',
       menuItemHTML: '<label class="multi-select-menuitem">',
       activeClass: 'multi-select-container--open',
-      placeholderText: '-- Select --'
+      noneText: '-- Select --',
+      allText: undefined
     };
 
   function Plugin(element, options) {
@@ -67,7 +68,7 @@
         'aria-haspopup': 'true',
         'tabindex': 0,
         'aria-label': this.$labels.eq(0).text()
-      }).text(this.settings.placeholderText)
+      })
       .on('keydown', function(e) {
         var key = e.which;
         var returnKey = 13;
@@ -188,18 +189,29 @@
 
     updateButtonContents: function() {
       var _this = this;
+      var options = [];
       var selected = [];
 
-      this.$element.children('option:selected').each(function() {
-        selected.push( $(this).text() );
+      this.$element.children('option').each(function() {
+        var text = $(this).text();
+        options.push(text);
+        if ($(this).is(':selected')) {
+          selected.push(text);
+        }
       });
 
       this.$button.empty();
 
-      if (selected.length > 0) {
-        this.$button.text( selected.join(', ') );
+      if (selected.length === options.length) {
+        if (this.settings.allText) {
+          this.$button.text( this.settings.allText );
+        } else {
+          this.$button.text( selected.join(', ') );
+        }
+      } else if (selected.length == 0) {
+        this.$button.text( this.settings.noneText );
       } else {
-        this.$button.text( this.settings.placeholderText );
+        this.$button.text( selected.join(', ') );
       }
     }
 

--- a/src/jquery.multi-select.js
+++ b/src/jquery.multi-select.js
@@ -38,9 +38,6 @@
       this.setUpBodyClickListener();
       this.setUpLabelsClickListener();
 
-      this.updateMenuContents();
-      this.updateButtonContents();
-
       this.$element.hide();
     },
 
@@ -85,6 +82,8 @@
       });
 
       this.$container.append(this.$button);
+
+      this.updateButtonContents();
     },
 
     constructMenu: function() {
@@ -114,6 +113,8 @@
       });
 
       this.$container.append(this.$menu);
+
+      this.updateMenuContents();
     },
 
     setUpBodyClickListener: function() {

--- a/test/spec/MultiSelectSpec.js
+++ b/test/spec/MultiSelectSpec.js
@@ -359,6 +359,68 @@ describe("When I press the escape key while the menu is focussed", function(){
   });
 });
 
+describe("When no <option>s are selected", function(){
+  var $select, $container;
+
+  afterEach(function(){
+    $select.remove();
+    $container.remove();
+  });
+
+  it("the button displays the default `noneText`", function() {
+    $select = helper.makeSelect().appendTo('body').multiSelect();
+    $container = $select.data('multiSelectContainer');
+
+    expect(
+      $container.find('.multi-select-button').text()
+    ).toEqual('-- Select --');
+  });
+
+  it("...or the button displays the custom `noneText`, if it is provided", function() {
+    $select = helper.makeSelect().appendTo('body').multiSelect({
+      'noneText': 'None of the options'
+    });
+    $container = $select.data('multiSelectContainer');
+
+    expect(
+      $container.find('.multi-select-button').text()
+    ).toEqual('None of the options');
+  });
+});
+
+describe("When all <option>s are selected", function(){
+  var $select, $container;
+
+  afterEach(function(){
+    $select.remove();
+    $container.remove();
+  });
+
+  it("the button displays a comma-separated list of checked options", function() {
+    $select = helper.makeSelect().appendTo('body').multiSelect();
+    $select.find('option').prop('selected', true);
+    $select.trigger('change');
+    $container = $select.data('multiSelectContainer');
+
+    expect(
+      $container.find('.multi-select-button').text()
+    ).toEqual('Alice, Bob, Carol');
+  });
+
+  it("...or the button displays the custom 'allText', if it is provided", function() {
+    $select = helper.makeSelect().appendTo('body').multiSelect({
+      'allText': 'All the options'
+    });
+    $select.find('option').prop('selected', true);
+    $select.trigger('change');
+    $container = $select.data('multiSelectContainer');
+
+    expect(
+      $container.find('.multi-select-button').text()
+    ).toEqual('All the options');
+  });
+});
+
 describe("I can customise", function() {
   it("the HTML markup of the container element", function() {
     var $select = helper.makeSelect().multiSelect({
@@ -424,15 +486,28 @@ describe("I can customise", function() {
       $container.remove();
   });
 
-  it("the placeholder text shown when no selections have been made", function() {
+  it("the text shown when no options have been selected", function() {
     var $select = helper.makeSelect().multiSelect({
-      placeholderText: 'My custom text'
+      noneText: 'No options selected'
     });
     var $container = $select.data('multiSelectContainer');
 
     expect(
       $container.find('.multi-select-button').text()
-    ).toEqual('My custom text');
+    ).toEqual('No options selected');
+  });
+
+  it("the text shown when all options have been selected", function() {
+    var $select = helper.makeSelect().multiSelect({
+      allText: 'All options selected'
+    });
+    $select.find('option').prop('selected', true);
+    $select.trigger('change');
+    var $container = $select.data('multiSelectContainer');
+
+    expect(
+      $container.find('.multi-select-button').text()
+    ).toEqual('All options selected');
   });
 });
 


### PR DESCRIPTION
`placeholderText` has now become `noneText`, and `allText` has been introduced as its equivalent for when all options are selected.

Fixes #1.