### PR TITLE
Config option to stop menu extending outside a parent element

### DIFF
--- a/demo/demo-styles.css
+++ b/demo/demo-styles.css
@@ -1,0 +1,71 @@
+*, *:before, *:after {
+    box-sizing: border-box;
+}
+
+*, body, button, input, textarea, select {
+    text-rendering: optimizeLegibility;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,form,fieldset,input,textarea,p,blockquote,th,td {
+    margin:0;
+    padding:0;
+}
+
+table {
+    border-collapse:collapse;
+    border-spacing:0;
+}
+
+fieldset,img {
+    border:0;
+}
+
+address,caption,cite,code,dfn,em,strong,th,var {
+    font-style:normal;
+    font-weight:normal;
+}
+
+ol,ul {
+    list-style:none;
+}
+
+caption,th {
+    text-align:left;
+}
+
+h1,h2,h3,h4,h5,h6 {
+    font-size:100%;
+    font-weight:normal;
+}
+
+q:before,q:after {
+    content:'';
+}
+
+abbr,acronym {
+    border: 0;
+}
+
+body {
+    font-family: sans-serif;
+    font-size: 16px;
+    line-height: 1.4;
+    padding: 2em;
+}
+
+label[for="people"],
+label[for="line-wrap-example"] {
+    display: block;
+    margin-bottom: 0.5em;
+    font-weight: bold;
+}
+
+.position-menu-within {
+    margin-top: 2em;
+    width: 18em;
+    height: 15em;
+    background: #eee;
+    overflow: auto;
+    padding: 2em 0 0 2em;
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8">
     <title>jquery-multi-select</title>
-    <link rel="stylesheet" type="text/css" href="style.css">
+    <link rel="stylesheet" type="text/css" href="../src/example-styles.css">
+    <link rel="stylesheet" type="text/css" href="demo-styles.css">
 </head>
 <body>
 
@@ -16,11 +17,23 @@
         </select>
     </form>
 
+    <div class="position-menu-within">
+        <label for="line-wrap-example">Line wrap example</label>
+        <select id="line-wrap-example" multiple>
+            <option>The final option…</option>
+            <option>Should wrap onto…</option>
+            <option>Multiple lines, to avoid expanding outside the grey wrapper</option>
+        </select>
+    </div>
+
     <script type="text/javascript" src="../test/lib/jquery-2.2.4.min.js"></script>
     <script type="text/javascript" src="../src/jquery.multi-select.js"></script>
     <script type="text/javascript">
     $(function(){
-        $('select').multiSelect();
+        $('#people').multiSelect();
+        $('#line-wrap-example').multiSelect({
+            positionMenuWithin: $('.position-menu-within')
+        });
     });
     </script>
 

--- a/src/example-styles.css
+++ b/src/example-styles.css
@@ -21,13 +21,14 @@
 .multi-select-menu label {
     display: block;
     font-size: 0.875em;
-    padding: 0.3em 1em;
+    padding: 0.3em 1em 0.3em 30px;
     white-space: nowrap;
 }
 
 .multi-select-menu input {
-    margin-right: 0.3em;
-    vertical-align: 0.1em;
+    position: absolute;
+    margin-top: 0.25em;
+    margin-left: -20px;
 }
 
 .multi-select-button {

--- a/src/example-styles.css
+++ b/src/example-styles.css
@@ -1,65 +1,3 @@
-*, *:before, *:after {
-    box-sizing: border-box;
-}
-
-*, body, button, input, textarea, select {
-    text-rendering: optimizeLegibility;
-    -moz-osx-font-smoothing: grayscale;
-}
-
-body,div,dl,dt,dd,ul,ol,li,h1,h2,h3,h4,h5,h6,pre,form,fieldset,input,textarea,p,blockquote,th,td {
-    margin:0;
-    padding:0;
-}
-
-table {
-    border-collapse:collapse;
-    border-spacing:0;
-}
-
-fieldset,img {
-    border:0;
-}
-
-address,caption,cite,code,dfn,em,strong,th,var {
-    font-style:normal;
-    font-weight:normal;
-}
-
-ol,ul {
-    list-style:none;
-}
-
-caption,th {
-    text-align:left;
-}
-
-h1,h2,h3,h4,h5,h6 {
-    font-size:100%;
-    font-weight:normal;
-}
-
-q:before,q:after {
-    content:'';
-}
-
-abbr,acronym {
-    border: 0;
-}
-
-body {
-    font-family: sans-serif;
-    font-size: 16px;
-    line-height: 1.4;
-    padding: 2em;
-}
-
-label[for="people"] {
-    display: block;
-    margin-bottom: 0.5em;
-    font-weight: bold;
-}
-
 .multi-select-container {
     display: inline-block;
     position: relative;
@@ -69,6 +7,7 @@ label[for="people"] {
     position: absolute;
     left: 0;
     top: 0.8em;
+    z-index: 1;
     float: left;
     min-width: 100%;
     background: #fff;
@@ -95,7 +34,7 @@ label[for="people"] {
     display: inline-block;
     font-size: 0.875em;
     padding: 0.2em 0.6em;
-    max-width: 20em;
+    max-width: 16em;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -126,4 +65,14 @@ label[for="people"] {
 .multi-select-container--open .multi-select-button:after {
     border-width: 0 0.4em 0.4em 0.4em;
     border-color: transparent transparent #999 transparent;
+}
+
+.multi-select-container--positioned .multi-select-menu {
+    /* Avoid border/padding on menu messing with JavaScript width calculation */
+    box-sizing: border-box;
+}
+
+.multi-select-container--positioned .multi-select-menu label {
+    /* Allow labels to line wrap when menu is artificially narrowed */
+    white-space: normal;
 }

--- a/src/jquery.multi-select.js
+++ b/src/jquery.multi-select.js
@@ -14,7 +14,9 @@
       menuItemHTML: '<label class="multi-select-menuitem">',
       activeClass: 'multi-select-container--open',
       noneText: '-- Select --',
-      allText: undefined
+      allText: undefined,
+      positionedMenuClass: 'multi-select-container--positioned',
+      positionMenuWithin: undefined
     };
 
   function Plugin(element, options) {
@@ -74,7 +76,7 @@
           _this.$button.click();
         }
       }).on('click', function(e) {
-        _this.$container.toggleClass(_this.settings.activeClass);
+        _this.menuToggle();
       });
 
       this.$element.on('change', function() {
@@ -96,7 +98,7 @@
         var key = e.which;
         var escapeKey = 27;
         if (key === escapeKey) {
-          _this.$container.removeClass(_this.settings.activeClass);
+          _this.menuHide();
         }
       });
 
@@ -122,7 +124,7 @@
 
       // Hide the $menu when you click outside of it.
       $('html').on('click', function(){
-        _this.$container.removeClass(_this.settings.activeClass);
+        _this.menuHide();
       });
 
       // Stop click events from inside the $button or $menu from
@@ -137,7 +139,7 @@
       this.$labels.on('click', function(e) {
         e.preventDefault();
         e.stopPropagation();
-        _this.$container.toggleClass(_this.settings.activeClass);
+        _this.menuToggle();
       });
     },
 
@@ -209,6 +211,34 @@
         this.$button.text( this.settings.allText );
       } else {
         this.$button.text( selected.join(', ') );
+      }
+    },
+
+    menuShow: function() {
+      this.$container.addClass(this.settings.activeClass);
+      if (this.settings.positionMenuWithin && this.settings.positionMenuWithin instanceof $) {
+        var menuLeftEdge = this.$menu.offset().left + this.$menu.outerWidth();
+        var withinLeftEdge = this.settings.positionMenuWithin.offset().left +
+          this.settings.positionMenuWithin.outerWidth();
+
+        if( menuLeftEdge > withinLeftEdge ) {
+          this.$menu.css( 'width', (withinLeftEdge - this.$menu.offset().left) );
+          this.$container.addClass(this.settings.positionedMenuClass);
+        }
+      }
+    },
+
+    menuHide: function() {
+      this.$container.removeClass(this.settings.activeClass);
+      this.$container.removeClass(this.settings.positionedMenuClass);
+      this.$menu.css('width', 'auto');
+    },
+
+    menuToggle: function() {
+      if ( this.$container.hasClass(this.settings.activeClass) ) {
+        this.menuHide();
+      } else {
+        this.menuShow();
       }
     }
 

--- a/test/SpecRunner.html
+++ b/test/SpecRunner.html
@@ -6,6 +6,8 @@
 
   <link rel="shortcut icon" type="image/png" href="lib/jasmine-2.4.1/jasmine_favicon.png">
   <link rel="stylesheet" href="lib/jasmine-2.4.1/jasmine.css">
+  <link rel="stylesheet" href="../src/example-styles.css">
+  <link rel="stylesheet" href="test-styles.css">
   <style>
   .jasmine_html-reporter { font-size: 1em; line-height: 1.4em; }
   </style>
@@ -23,6 +25,5 @@
 </head>
 
 <body>
-    <div id="foo"></div>
 </body>
 </html>

--- a/test/spec/MultiSelectSpec.js
+++ b/test/spec/MultiSelectSpec.js
@@ -17,6 +17,25 @@ var helper = {
   }
 }
 
+var customMatchers = {
+  toBeLessThanOrEqualTo: function() {
+    return {
+      compare: function(firstThing, secondThing) {
+        var result = {
+          pass: firstThing <= secondThing
+        };
+        if (result.pass) {
+          // Used in the case of a .not matcher
+          result.message = "Expected " + firstThing + " not to be less than or equal to " + secondThing;
+        } else {
+          result.message = "Expected " + firstThing + " to be less than or equal to " + secondThing;
+        }
+        return result;
+      }
+    }
+  }
+}
+
 describe("$(element).multiSelect()", function() {
 
   it("should be a jQuery plugin", function() {
@@ -561,5 +580,31 @@ describe("I can customise", function() {
       $container.find('.multi-select-button').text()
     ).toEqual('All options selected');
   });
+
+  it("an element within which the menu should be contained", function() {
+    jasmine.addMatchers(customMatchers);
+
+    var $within = $('<div>').addClass('position-menu-within').appendTo('body');
+    var $select = helper.makeSelect({
+      'The final option…': [],
+      'Should wrap onto…': [],
+      'Multiple lines, to avoid expanding outside the grey wrapper': []
+    }).appendTo($within);
+    $select.multiSelect({
+      positionMenuWithin: $within
+    });
+    var $container = $select.data('multiSelectContainer');
+    var $menu = $container.find('.multi-select-menu');
+
+    $container.children('.multi-select-button').trigger('click');
+
+    expect(
+      $menu.offset().left + $menu.outerWidth()
+    ).toBeLessThanOrEqualTo(
+      $within.offset().left + $within.outerWidth()
+    );
+
+    $within.remove();
+  })
 });
 

--- a/test/test-styles.css
+++ b/test/test-styles.css
@@ -1,0 +1,12 @@
+.position-menu-within {
+    margin-top: 2em;
+    width: 18em;
+    height: 15em;
+    background: #eee;
+    overflow: auto;
+    padding: 2em 0 0 2em;
+
+    font-size: 16px;
+    line-height: 1.4;
+    font-family: sans-serif;
+}


### PR DESCRIPTION
If `positionMenuWithin` is specified, the width of the menu is artificially constrained, such that it does not extend outside the bounds of the `positionMenuWithin` element when it is shown.

This was the first test that really required CSS styles (for the width and position calculations) so it necessitated a tidying up of the CSS files in `/demo`.