### PR TITLE
Remove `for` attribute from labels when creating a multiSelect

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Converts `<select multiple>` elements into dropdown menus with a checkbox for each `<option>`.
 
+The original `<select>` element is hidden, but still present in the document, and will be updated with any selections made via the custom dropdown menu.
+
+Any labels associated with the original `<select>` element will have their `for=` attributes removed, so as not to be left associated with a hidden form element. Clicking the labels will open the dropdown menu as expected.
+
 ## Use this plugin
 
 Assuming HTML markup like this:

--- a/spec/MultiSelectSpec.js
+++ b/spec/MultiSelectSpec.js
@@ -101,7 +101,40 @@ describe("$(element).multiSelect().data('multiSelectContainer')", function() {
       $container.find('input:checkbox').length
     ).toEqual(3);
   });
+});
 
+describe("Calling .multiSelect() on a <select> referred to by one or more <label>s", function() {
+  var $select, $parent, $label1, $label2;
+
+  beforeEach(function(){
+    $parent = $('<div>').appendTo('body');
+    $select = helper.makeSelect().attr('id', 'select-with-labels').appendTo($parent);
+    $label1 = $('<label for="select-with-labels">Label 1</label>').appendTo($parent);
+    $label2 = $('<label for="select-with-labels">Label 2</label>').appendTo($parent);
+    $select.multiSelect();
+  });
+
+  afterEach(function(){
+    $parent.remove();
+  });
+
+  it("removes the `for` attribute from the labels", function() {
+    expect(
+      $label1.attr('for')
+    ).toBeUndefined();
+    expect(
+      $label2.attr('for')
+    ).toBeUndefined();
+  });
+
+  it("shows the menu when one of the labels is clicked", function(){
+    var $container = $select.data('multiSelectContainer');
+    $label1.trigger('click');
+
+    expect(
+      $container.hasClass('multi-select-container--open')
+    ).toBe(true);
+  });
 });
 
 describe("Calling .multiSelect() on a <select> with pre-selected <options>", function() {

--- a/src/jquery.multi-select.js
+++ b/src/jquery.multi-select.js
@@ -68,7 +68,7 @@
       this.setUpBodyClickListener();
       this.setUpLabelsClickListener();
 
-      this.$element.hide();
+      this.hideOriginalElement();
     },
 
     checkSuitableInput: function(text) {
@@ -378,6 +378,11 @@
         e.stopPropagation();
         _this.menuToggle();
       });
+    },
+
+    hideOriginalElement: function() {
+      this.$element.hide();
+      this.$labels.removeAttr('for');
     },
 
     menuShow: function() {


### PR DESCRIPTION
It was noted that it’s bad practice to leave a `<label>` pointing at a hidden form element. So, if the `<select>` we’re converting is referenced in the `for` attribute of any `<label>`s in the document, we remove those `for` attribute, so the label isn’t left pointing at a hidden form element.

Fixes #28.